### PR TITLE
jws: _cjose_jws_build_dig_sha: fix jws->dig reuse memory leak

### DIFF
--- a/src/jws.c
+++ b/src/jws.c
@@ -173,8 +173,8 @@ static bool _cjose_jws_build_dig_sha(cjose_jws_t *jws, const cjose_jwk_t *jwk, c
 
     if (NULL != jws->dig)
     {
-    	cjose_get_dealloc()(jws->dig);
-    	jws->dig = NULL;
+        cjose_get_dealloc()(jws->dig);
+        jws->dig = NULL;
     }
 
     // allocate buffer for digest
@@ -262,6 +262,12 @@ static bool _cjose_jws_build_dig_hmac_sha(cjose_jws_t *jws, const cjose_jwk_t *j
     {
         CJOSE_ERROR(err, CJOSE_ERR_CRYPTO);
         goto _cjose_jws_build_dig_hmac_sha_cleanup;
+    }
+
+    if (NULL != jws->dig)
+    {
+        cjose_get_dealloc()(jws->dig);
+        jws->dig = NULL;
     }
 
     // allocate buffer for digest


### PR DESCRIPTION
This fixes a memory leak already addressed in _cjose_jws_build_dig_sha when a jws is reused for a validation.