### PR TITLE
Define OPENSSL_API_COMPAT to 0x10101000L

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
  */
 
+#define OPENSSL_API_COMPAT 0x10101000L
+
 #include <cjose/base64.h>
 #include <cjose/header.h>
 #include <cjose/jwe.h>

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
  */
 
+#define OPENSSL_API_COMPAT 0x10101000L
+
 #include "include/jwk_int.h"
 #include "include/util_int.h"
 

--- a/src/jws.c
+++ b/src/jws.c
@@ -5,6 +5,8 @@
  * Copyright (c) 2014-2016 Cisco Systems, Inc.  All Rights Reserved.
  */
 
+#define OPENSSL_API_COMPAT 0x10101000L
+
 #include <cjose/base64.h>
 #include <cjose/header.h>
 #include <cjose/jws.h>


### PR DESCRIPTION
This enables compiling cjose on systems that only ship openssl v3.

It is not a very systematic patch, but at least cjose builds...