### PR TITLE
Fix `make` on `srcdir != builddir`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -I$(top_builddir)/include
 
 lib_LTLIBRARIES=libcjose.la
-libcjose_la_CPPFLAGS= -I$(topdir)/include
+libcjose_la_CPPFLAGS= -I$(top_srcdir)/include
 libcjose_la_LDFLAGS= -lm
 libcjose_la_SOURCES=version.c \
 					util.c \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -7,7 +7,7 @@ TESTS = check_cjose
 
 check_PROGRAMS = $(TESTS)
 check_cjose_CFLAGS = @CHECK_CFLAGS@ -I$(top_builddir)/include \
-                     -I$(top_builddir)/src
+                     -I$(top_builddir)/src -I$(top_srcdir)/src
 check_cjose_LDADD = $(top_builddir)/src/libcjose.la @CHECK_LIBS@
 check_cjose_SOURCES = check_cjose.c \
                       check_version.c \


### PR DESCRIPTION
```
$ cd /usr/src
$ git clone https://github.com/zmartzone/cjose.git
$ cd /tmp/cjose
$ /usr/src/cjose/configure
$ make check
/use/src/cjose/test/check_util.c:7:10: fatal error: include/util_int.h: No such file or directory
    7 | #include "include/util_int.h"
      |          ^~~~~~~~~~~~~~~~~~~~
```