### PR TITLE
Build shared library on cygwin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS =-std=gnu99 --pedantic -Wall -Werror -g -O2 -I$(top_builddir)/include
 
 lib_LTLIBRARIES=libcjose.la
 libcjose_la_CPPFLAGS= -I$(top_srcdir)/include
-libcjose_la_LDFLAGS= -lm
+libcjose_la_LDFLAGS= -no-undefined -lm
 libcjose_la_SOURCES=version.c \
 					util.c \
 					base64.c \


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-0.367.gc49bc478b4a7.x86_64 2023-08-02 15:46 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/OpenIDC/cjose.git
$ cd cjose
$ ./configure --enable-shared --disable-static
$ make
: 
/bin/sh ../libtool  --tag=CC   --mode=link gcc -std=gnu99 --pedantic -Wall -Werror -g -O2 -I../include -g -O2 -lm  -o libcjose.la -rpath /usr/local/lib libcjose_la-version.lo libcjose_la-util.lo libcjose_la-base64.lo libcjose_la-concatkdf.lo libcjose_la-jwk.lo libcjose_la-jwe.lo libcjose_la-jws.lo libcjose_la-header.lo libcjose_la-error.lo  -ljansson -lcrypto
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
```

Due to Windows platform limitations, this option is required when building shared libraries.
Without this option, only static libraries can be built.

https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
> This option should be used if the package has been ported to build clean dlls on win32 platforms. Usually this means that any library data items are exported with __declspec(dllexport) and imported with __declspec(dllimport). If this option is not used, libtool will assume that the package libraries are not dll clean and will build only static libraries on win32 hosts.
> 
> Provision must be made to pass -no-undefined to libtool in link mode from the package Makefile. Naturally, if you pass -no-undefined, you must ensure that all the library symbols really are defined at link time!
