### PR TITLE
Fix compilation errors caused by function declarations without parameters

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -21,39 +21,39 @@ static cjose_alloc3_fn_t _alloc3;
 static cjose_realloc3_fn_t _realloc3;
 static cjose_dealloc3_fn_t _dealloc3;
 
-void *cjose_alloc_wrapped(size_t n) { return cjose_get_alloc3()(n, __FILE__, __LINE__); }
-void *cjose_realloc_wrapped(void *p, size_t n) { return cjose_get_realloc3()(p, n, __FILE__, __LINE__); }
-void cjose_dealloc_wrapped(void *p) { cjose_get_dealloc3()(p, __FILE__, __LINE__); }
+void *cjose_alloc_wrapped(size_t n) { return cjose_get_alloc3(void)(n, __FILE__, __LINE__); }
+void *cjose_realloc_wrapped(void *p, size_t n) { return cjose_get_realloc3(void)(p, n, __FILE__, __LINE__); }
+void cjose_dealloc_wrapped(void *p) { cjose_get_dealloc3(void)(p, __FILE__, __LINE__); }
 
 void *cjose_alloc3_default(size_t n, const char *file, int line)
 {
     CJOSE_UNUSED_PARAM(file);
     CJOSE_UNUSED_PARAM(line);
-    return cjose_get_alloc()(n);
+    return cjose_get_alloc(void)(n);
 }
 
 void *cjose_realloc3_default(void *p, size_t n, const char *file, int line)
 {
     CJOSE_UNUSED_PARAM(file);
     CJOSE_UNUSED_PARAM(line);
-    return cjose_get_realloc()(p, n);
+    return cjose_get_realloc(void)(p, n);
 }
 
 void cjose_dealloc3_default(void *p, const char *file, int line)
 {
     CJOSE_UNUSED_PARAM(file);
     CJOSE_UNUSED_PARAM(line);
-    cjose_get_dealloc()(p);
+    cjose_get_dealloc(void)(p);
 }
 
 static void cjose_apply_allocs(void)
 {
     // set upstream
-    json_set_alloc_funcs(cjose_get_alloc(), cjose_get_dealloc());
+    json_set_alloc_funcs(cjose_get_alloc(void), cjose_get_dealloc(void));
 #if defined(CJOSE_OPENSSL_11X)
-    CRYPTO_set_mem_functions(cjose_get_alloc3(), cjose_get_realloc3(), cjose_get_dealloc3());
+    CRYPTO_set_mem_functions(cjose_get_alloc3(void), cjose_get_realloc3(void), cjose_get_dealloc3(void));
 #else
-    CRYPTO_set_mem_functions(cjose_get_alloc(), cjose_get_realloc(), cjose_get_dealloc());
+    CRYPTO_set_mem_functions(cjose_get_alloc(void), cjose_get_realloc(void), cjose_get_dealloc(void));
 #endif
 }
 
@@ -67,7 +67,7 @@ void cjose_set_alloc_funcs(cjose_alloc_fn_t alloc, cjose_realloc_fn_t realloc, c
     _realloc3 = cjose_realloc3_default;
     _dealloc3 = cjose_dealloc3_default;
 
-    cjose_apply_allocs();
+    cjose_apply_allocs(void);
 }
 
 void cjose_set_alloc_ex_funcs(cjose_alloc3_fn_t alloc3, cjose_realloc3_fn_t realloc3, cjose_dealloc3_fn_t dealloc3)
@@ -80,7 +80,7 @@ void cjose_set_alloc_ex_funcs(cjose_alloc3_fn_t alloc3, cjose_realloc3_fn_t real
     _realloc = (NULL != realloc3) ? cjose_realloc_wrapped : NULL;
     _dealloc = (NULL != dealloc3) ? cjose_dealloc_wrapped : NULL;
 
-    cjose_apply_allocs();
+    cjose_apply_allocs(void);
 }
 
 cjose_alloc_fn_t cjose_get_alloc(void) { return (!_alloc) ? malloc : _alloc; }
@@ -116,7 +116,7 @@ char *_cjose_strndup(const char *str, ssize_t len, cjose_err *err)
         len = strlen(str);
     }
 
-    char *result = cjose_get_alloc()(sizeof(char) * (len + 1));
+    char *result = cjose_get_alloc(void)(sizeof(char) * (len + 1));
     if (!result)
     {
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
@@ -143,7 +143,7 @@ json_t *_cjose_json_stringn(const char *value, size_t len, cjose_err *err)
         CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
         return NULL;
     }
-    cjose_get_dealloc()(s);
+    cjose_get_dealloc(void)(s);
 #else
     result = json_stringn(value, len);
     if (!result)


### PR DESCRIPTION
This commit addresses the following compilation errors:
- Warnings were raised due to function declarations without parameters, which are deprecated in all versions of C.
- Functions such as `cjose_get_alloc()`, `cjose_get_alloc3()`, `cjose_get_realloc()`, `cjose_get_realloc3()`, `cjose_get_dealloc()`, and `cjose_get_dealloc3()` were declared without a `void` parameter.
- Modified these declarations and definitions by adding `void` to indicate no parameters, as required by modern C standards.

This change resolves the compilation errors when building with strict prototype checking (-Wstrict-prototypes).

> [ 1871s] In file included from util.c:10:
> [ 1871s] ../include/cjose/util.h:112:33: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   112 | cjose_alloc_fn_t cjose_get_alloc();
> [ 1871s]       |                                 ^
> [ 1871s]       |                                  void
> [ 1871s] ../include/cjose/util.h:122:35: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   122 | cjose_alloc3_fn_t cjose_get_alloc3();
> [ 1871s]       |                                   ^
> [ 1871s]       |                                    void
> [ 1871s] ../include/cjose/util.h:130:37: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   130 | cjose_realloc_fn_t cjose_get_realloc();
> [ 1871s]       |                                     ^
> [ 1871s]       |                                      void
> [ 1871s] ../include/cjose/util.h:140:39: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   140 | cjose_realloc3_fn_t cjose_get_realloc3();
> [ 1871s]       |                                       ^
> [ 1871s]       |                                        void
> [ 1871s] ../include/cjose/util.h:148:37: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   148 | cjose_dealloc_fn_t cjose_get_dealloc();
> [ 1871s]       |                                     ^
> [ 1871s]       |                                      void
> [ 1871s] ../include/cjose/util.h:158:39: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]   158 | cjose_dealloc3_fn_t cjose_get_dealloc3();
> [ 1871s]       |                                       ^
> [ 1871s]       |                                        void
> [ 1871s] util.c:49:31: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    49 | static void cjose_apply_allocs()
> [ 1871s]       |                               ^
> [ 1871s]       |                                void
> [ 1871s] util.c:86:33: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    86 | cjose_alloc_fn_t cjose_get_alloc() { return (!_alloc) ? malloc : _alloc; }
> [ 1871s]       |                                 ^
> [ 1871s]       |                                  void
> [ 1871s] util.c:87:35: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    87 | cjose_alloc3_fn_t cjose_get_alloc3() { return (!_alloc3) ? cjose_alloc3_default : _alloc3; }
> [ 1871s]       |                                   ^
> [ 1871s]       |                                    void
> [ 1871s] util.c:89:37: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    89 | cjose_realloc_fn_t cjose_get_realloc() { return (!_realloc) ? realloc : _realloc; }
> [ 1871s]       |                                     ^
> [ 1871s]       |                                      void
> [ 1871s] util.c:90:39: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    90 | cjose_realloc3_fn_t cjose_get_realloc3() { return (!_realloc3) ? cjose_realloc3_default : _realloc3; }
> [ 1871s]       |                                       ^
> [ 1871s]       |                                        void
> [ 1871s] util.c:92:37: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    92 | cjose_dealloc_fn_t cjose_get_dealloc() { return (!_dealloc) ? free : _dealloc; }
> [ 1871s]       |                                     ^
> [ 1871s]       |                                      void
> [ 1871s] util.c:93:39: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
> [ 1871s]    93 | cjose_dealloc3_fn_t cjose_get_dealloc3() { return (!_dealloc3) ? cjose_dealloc3_default : _dealloc3; }
> [ 1871s]       |                                       ^
> [ 1871s]       |                                        void
> [ 1871s] 13 errors generated.
> [ 1871s] make[1]: *** [Makefile:510: libcjose_la-util.lo] Error 1