### PR TITLE
Fix the compilation errors in gcc-10 with `-Werror=ignored-qualifiers` option and remove unused lines related to alloca

### DIFF
--- a/include/cjose/jwk.h
+++ b/include/cjose/jwk.h
@@ -282,7 +282,7 @@ cjose_jwk_t *cjose_jwk_create_EC_spec(const cjose_jwk_ec_keyspec *spec, cjose_er
  *        information in the event of an error.
  * \returns The curve type
  */
-const cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err);
+cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err);
 
 /**
  * Creates a new symmetric octet JWK, using a secure random number generator.

--- a/src/concatkdf.c
+++ b/src/concatkdf.c
@@ -12,18 +12,11 @@
 #include <malloc.h>
 #else
 #include <arpa/inet.h>
-#include <alloca.h>
 #endif
 #include <openssl/evp.h>
 #include <string.h>
 #include <cjose/base64.h>
 #include <cjose/util.h>
-
-#ifdef _WIN32
-#define STACK_ALLOC _alloca
-#else
-#define STACK_ALLOC alloca
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 static uint8_t *_apply_uint32(const uint32_t value, uint8_t *buffer)

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1002,7 +1002,7 @@ create_EC_cleanup:
     return jwk;
 }
 
-const cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
+cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
 {
     if (NULL == jwk || CJOSE_JWK_KTY_EC != cjose_jwk_get_kty(jwk, err))
     {


### PR DESCRIPTION
I found a build error and unused header file.

## 1. `-Werror=ignored-qualifiers` 

``` 
hidden/cjose/src/jwk.c:1005:1: error: type qualifiers ignored on function return type [-Werror=ignored-qualifiers]
1005 | const cjose_jwk_ec_curve cjose_jwk_EC_get_curve(const cjose_jwk_t *jwk, cjose_err *err)
     | ^~~~~
```

Currently,  cjose_jwk_ec_curve is an enumeration so it seems that `const` qualifier can not be used.

https://github.com/OpenIDC/cjose/blob/b8f607de2b81ed54a49d46afc0e90ee75b21b9c7/include/cjose/jwk.h#L216-L226

## alloca

`alloca()` was used in src/concatkdf.c but it is no longer used after https://github.com/OpenIDC/cjose/pull/15