### PR TITLE
ci: build and test with clang in addition to gcc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
       env:
         CK_FORK: no
       run: |
-        valgrind --leak-check=full --error-exitcode=1 --show-possibly-lost=no --read-inline-info=yes --keep-debuginfo=yes ./test/check_cjose
+        ./libtool --mode=execute valgrind --leak-check=full --error-exitcode=1 --show-possibly-lost=no --read-inline-info=yes --keep-debuginfo=yes ./test/check_cjose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,4 @@ jobs:
       env:
         CK_FORK: no
       run: |
-        valgrind --leak-check=full --error-exitcode=1 --show-possibly-lost=no --read-inline-info=yes --keep-debuginfo=yes --undef-value-errors=no ./test/check_cjose
+        valgrind --leak-check=full --error-exitcode=1 --show-possibly-lost=no --read-inline-info=yes --keep-debuginfo=yes ./test/check_cjose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,22 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build with ${{ matrix.cc }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+
+    env:
+      CC: ${{ matrix.cc }}
+
     steps:
     - uses: actions/checkout@v5
     - name: Dependencies
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y pkg-config make gcc valgrind autoconf automake libtool
+        sudo apt-get install -y pkg-config make ${{ matrix.cc }} valgrind autoconf automake libtool
         sudo apt-get install -y libssl-dev libjansson-dev check
     - name: Configure
       run: |
@@ -21,6 +31,7 @@ jobs:
     - name: Test
       run: make check || { cat test/test-suite.log && (exit -1) }
     - name: Valgrind
+      if: matrix.cc == 'gcc'
       env:
         CK_FORK: no
       run: |


### PR DESCRIPTION
Adds a `clang` leg to the Build workflow.

### Why

The workflow only ever installed `gcc`, so nothing in CI has ever exercised clang. That gap let a `-Wsometimes-uninitialized` regression into `src/jwk.c` in 1a419a8 — and since `src/Makefile.am` builds with `-Werror`, **v0.6.2.6 and v0.6.2.7 both ship a tree that cannot be built with clang at all**, while CI stayed green the whole time. It took a downstream report (#32) to surface it.

GCC 15 does not diagnose that pattern even under `-Wextra`, so this is not something a stricter gcc flag would have caught — it needs the second compiler.

### What

`build` becomes a compiler matrix over `gcc` and `clang`, with `fail-fast: false` so one compiler failing still reports the other. `CC` is set per-leg; `./configure` picks it up.

Valgrind stays on the gcc leg only (`if: matrix.cc == 'gcc'`) — it exercises runtime behavior rather than anything compiler-specific, and running it on both legs would just double the job time for no added coverage.

### Verification

Locally, with `--with-rsapkcs1_5` (matching the CI invocation) and clang 21:

* On `version-0.6.2.x` HEAD: `CC=clang ./configure && make` fails with 20+ `-Werror,-Wsometimes-uninitialized` errors in `jwk.c` — i.e. the new leg does catch the regression it is meant to catch.
* With #32 applied: builds clean and `make check` passes, 85/85 tests, 0 failures.

### Merge order

**Merge #32 and #34 first, then this.** Both new checks are red until they land, which is the point of them, but worth knowing before hitting merge:

* the `clang` leg fails until #32 fixes `jwk.c`
* the `valgrind` step fails until #34 fixes the pre-existing test leaks

### Valgrind: uninitialised-value reporting re-enabled

The step passed `--undef-value-errors=no`, switching off exactly the class of error relevant to the `jwk.c` regression. Second commit drops that flag.

Measured before changing it (gcc, `--with-rsapkcs1_5`, valgrind 3.26, OpenSSL 3.x): **enabling the check adds zero findings.** The suite reports 15 errors with the flag and 15 without, and all 15 are pre-existing leaks — no uninitialised-value reports at all. There is no OpenSSL noise to suppress.

### Valgrind: now actually instruments the test binary

Re-enabling the flag above turned out to change nothing, because **the valgrind step has never instrumented the test binary at all.** `test/check_cjose` is a libtool wrapper shell script; the real binary is `test/.libs/check_cjose`. Valgrind traced the wrapper's bash and stopped at the `exec`, so the step reported `0 errors from 0 contexts` vacuously — for as long as it has existed.

Third commit runs it under `./libtool --mode=execute`, which resolves the wrapper and puts valgrind on the real binary with the right library path. `--trace-children=yes` also works but is worse: it additionally instruments the `/usr/bin/sed` the wrapper shells out to, and reports leaks inside *sed*.

With the invocation fixed, exactly one process is traced and 15 pre-existing leaks appear — all in the test files, none in `src/`. Those are fixed in **#34**, which must land before this PR.

### Also not included

`archs.yml` is gcc-only too; adding clang across the emulated cross-arch matrix would be considerably more expensive and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



