### PR TITLE
jwk: initialize the decoded buffer lengths up front

### DIFF
--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1371,6 +1371,9 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     uint8_t *x_buffer = NULL;
     uint8_t *y_buffer = NULL;
     uint8_t *d_buffer = NULL;
+    size_t x_buflen = 0;
+    size_t y_buflen = 0;
+    size_t d_buflen = 0;
 
     // get the value of the crv attribute
     const char *crv_str = _get_json_object_string_attribute(jwk_json, CJOSE_JWK_CRV_STR, err);
@@ -1389,7 +1392,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the x coordinate
-    size_t x_buflen = (size_t)_ec_size_for_curve(crv, err);
+    x_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_X_STR, &x_buffer, &x_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1397,7 +1400,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the y coordinate
-    size_t y_buflen = (size_t)_ec_size_for_curve(crv, err);
+    y_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Y_STR, &y_buffer, &y_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1405,7 +1408,7 @@ static cjose_jwk_t *_cjose_jwk_import_EC(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of the private key d
-    size_t d_buflen = (size_t)_ec_size_for_curve(crv, err);
+    d_buflen = (size_t)_ec_size_for_curve(crv, err);
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1455,9 +1458,16 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     uint8_t *dp_buffer = NULL;
     uint8_t *dq_buffer = NULL;
     uint8_t *qi_buffer = NULL;
+    size_t n_buflen = 0;
+    size_t e_buflen = 0;
+    size_t d_buflen = 0;
+    size_t p_buflen = 0;
+    size_t q_buflen = 0;
+    size_t dp_buflen = 0;
+    size_t dq_buflen = 0;
+    size_t qi_buflen = 0;
 
     // get the decoded value of n (buflen = 0 means no particular expected len)
-    size_t n_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_N_STR, &n_buffer, &n_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1465,7 +1475,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of e
-    size_t e_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_E_STR, &e_buffer, &e_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1473,7 +1482,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of d
-    size_t d_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_D_STR, &d_buffer, &d_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1481,7 +1489,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of p
-    size_t p_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_P_STR, &p_buffer, &p_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1489,7 +1496,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of q
-    size_t q_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_Q_STR, &q_buffer, &q_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1497,7 +1503,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of dp
-    size_t dp_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DP_STR, &dp_buffer, &dp_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1505,7 +1510,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of dq
-    size_t dq_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_DQ_STR, &dq_buffer, &dq_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
@@ -1513,7 +1517,6 @@ static cjose_jwk_t *_cjose_jwk_import_RSA(json_t *jwk_json, cjose_err *err)
     }
 
     // get the decoded value of qi
-    size_t qi_buflen = 0;
     if (!_decode_json_object_base64url_attribute(jwk_json, CJOSE_JWK_QI_STR, &qi_buffer, &qi_buflen, err))
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);


### PR DESCRIPTION
Supersedes #32. **The patch is @kraj's, unchanged** — `git diff` against their commit is empty, and git authorship still records them as the author. Only the commit message differs, applying the rewording discussed in https://github.com/OpenIDC/cjose/pull/32#issuecomment-5200606953.

Opening this rather than force-pushing over the contributor's branch.

### The fix

`_cjose_jwk_import_EC()` and `_cjose_jwk_import_RSA()` declare their `*_buflen` variables mid-function, interleaved with error paths that `goto` a shared cleanup label. An early decode failure jumps over the remaining declarations, and the cleanup block then reads them uninitialized. Declaring the lengths alongside the buffers they pair with fixes it.

### Why the message changed

The original described this as "a real out-of-bounds write hazard on the error path". That doesn't hold:

* `_cjose_cleanse_dealloc()` (`src/util.c:103`) returns immediately when `ptr == NULL`, so the length is never used.
* On every `goto import_RSA_cleanup` path, each still-uninitialized `*_buflen` is paired with a `NULL` buffer — the buffers are NULL-initialized at the top of the function, and `_decode_json_object_base64url_attribute()` sets `*buffer = NULL` on its own failure (`src/jwk.c:1355`, `1363`).

So an indeterminate length always pairs with a NULL pointer and no wipe is ever attempted. What remains is real UB — evaluating an indeterminate `size_t` as a function argument (C11 6.3.2.1p2), which is what clang objects to — plus a hard build failure under `-Werror`. Ample reason to fix, and the invariant is too implicit to rely on, but it is not memory corruption and the 0.6.2.8 CHANGELOG should not read as though 0.6.2.7 had it in a pre-auth import path.

### Impact

Bisected to 1a419a8 (2026-06-02), which introduced the unconditional `_cjose_cleanse_dealloc()` cleanup block; its parent is clean. That commit is in **v0.6.2.6 and v0.6.2.7**, so both released tags are unbuildable with clang, since `src/Makefile.am` builds with `-Werror`.

### Verification

On this branch, clang 21, `--with-rsapkcs1_5`:

* Before: `make` fails with 20+ `-Werror,-Wsometimes-uninitialized` errors in `jwk.c` (27 diagnostics total, all from `_cjose_jwk_import_RSA`).
* After: builds clean, `make check` passes 85/85.

GCC 15 does not diagnose this even under `-Wextra`, which is why CI never caught it. #33 adds a clang leg to close that gap.

### Notes

* The EC hunk silences nothing on its own — `x_buflen`/`y_buflen` are never read in `import_EC_cleanup` (plain `cjose_get_dealloc()`), and `d_buflen` is read only under `if (NULL != d_buffer)`. Kept for symmetry.
* No regression test: there is no observable behavior change to assert on. The guard is CI clang coverage.
* CHANGELOG entry to be added when cutting 0.6.2.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
