### PR TITLE
Fix: enforce minimum 2048 bit rsa modulus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   (https://github.com/OpenIDC/cjose/pull/32); thanks @kraj
 * Use a portable thread-local storage specifier in `error.c` so the OpenSSL error buffer builds
   with MSVC.
+* **Security fix**: enforce the RFC 7518 section 3.3 minimum 2048-bit RSA modulus in
+  `cjose_jwk_create_RSA_random` and `cjose_jwk_create_RSA_spec`; note that sub-2048-bit RSA
+  keys are now rejected at creation/import time
+  (https://github.com/OpenIDC/cjose/pull/36, ported from https://github.com/cisco/cjose/pull/136);
+  thanks @kunqn
 
 <a name="v0.6.2.7"></a>
 ## [v0.6.2.7](https://github.com/OpenIDC/cjose/compare/v0.6.2.6...v0.6.2.7)  (2026-06-03)

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1253,10 +1253,14 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
 
     // RFC 7518 §3.3 requires minimum 2048-bit RSA modulus for RS*/PS*/RSA-OAEP/RSA1_5
     BIGNUM *n_bn = BN_bin2bn(spec->n, spec->nlen, NULL);
-    if (NULL == n_bn || BN_num_bits(n_bn) < 2048)
+    if (NULL == n_bn)
     {
-        if (n_bn)
-            BN_free(n_bn);
+        CJOSE_ERROR(err, CJOSE_ERR_NO_MEMORY);
+        return NULL;
+    }
+    if (BN_num_bits(n_bn) < 2048)
+    {
+        BN_free(n_bn);
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
     }

--- a/src/jwk.c
+++ b/src/jwk.c
@@ -1185,7 +1185,8 @@ static const size_t DEFAULT_E_LEN = 3;
 
 cjose_jwk_t *cjose_jwk_create_RSA_random(size_t keysize, const uint8_t *e, size_t elen, cjose_err *err)
 {
-    if (0 == keysize)
+    // RFC 7518 §3.3 requires minimum 2048-bit RSA modulus for RS*/PS*/RSA-OAEP/RSA1_5
+    if (keysize < 2048)
     {
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
@@ -1249,6 +1250,17 @@ cjose_jwk_t *cjose_jwk_create_RSA_spec(const cjose_jwk_rsa_keyspec *spec, cjose_
         CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
         return NULL;
     }
+
+    // RFC 7518 §3.3 requires minimum 2048-bit RSA modulus for RS*/PS*/RSA-OAEP/RSA1_5
+    BIGNUM *n_bn = BN_bin2bn(spec->n, spec->nlen, NULL);
+    if (NULL == n_bn || BN_num_bits(n_bn) < 2048)
+    {
+        if (n_bn)
+            BN_free(n_bn);
+        CJOSE_ERROR(err, CJOSE_ERR_INVALID_ARG);
+        return NULL;
+    }
+    BN_free(n_bn);
 
     RSA *rsa = NULL;
     rsa = RSA_new();

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1424,6 +1424,80 @@ START_TEST(test_cjose_jwk_get_and_set_kid)
 }
 END_TEST
 
+// 512-bit RSA test key (modulus and exponent in base64url format)
+// Generated for testing weak RSA key rejection per RFC 7518 §3.3
+const char *RSA_512_n = "kGiKm3yt90sKJPGUF0hBbHJPOPHG5V5CfDe-YZ0E3D7KvXjBT_IJZR6n8ZKnEwYSVXxKJ6rlx5Vvg5gvq1QQ2w";
+const char *RSA_512_e = "AQAB";
+
+START_TEST(test_cjose_jwk_create_RSA_random_weak_keysize)
+{
+    cjose_err err;
+    cjose_jwk_t *jwk = NULL;
+    uint8_t *e = (uint8_t *)"\x01\x00\x01";
+    size_t elen = 3;
+
+    // Test that 512-bit keys are rejected (< 2048)
+    jwk = cjose_jwk_create_RSA_random(512, e, elen, &err);
+    ck_assert_msg(NULL == jwk, "expected NULL for 512-bit key, but got a cjose_jwk_t");
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // Test that 1024-bit keys are rejected (< 2048)
+    jwk = cjose_jwk_create_RSA_random(1024, e, elen, &err);
+    ck_assert_msg(NULL == jwk, "expected NULL for 1024-bit key, but got a cjose_jwk_t");
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // Test that 2047-bit keys are rejected (< 2048)
+    jwk = cjose_jwk_create_RSA_random(2047, e, elen, &err);
+    ck_assert_msg(NULL == jwk, "expected NULL for 2047-bit key, but got a cjose_jwk_t");
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // Test that 2048-bit keys are accepted (>= 2048)
+    jwk = cjose_jwk_create_RSA_random(2048, e, elen, &err);
+    ck_assert_msg(NULL != jwk, "expected a cjose_jwk_t for 2048-bit key, but got NULL");
+    cjose_jwk_release(jwk);
+
+    // Test that 4096-bit keys are accepted (> 2048)
+    jwk = cjose_jwk_create_RSA_random(4096, e, elen, &err);
+    ck_assert_msg(NULL != jwk, "expected a cjose_jwk_t for 4096-bit key, but got NULL");
+    cjose_jwk_release(jwk);
+}
+END_TEST
+
+START_TEST(test_cjose_jwk_create_RSA_spec_weak_modulus)
+{
+    cjose_err err;
+    cjose_jwk_rsa_keyspec spec;
+    cjose_jwk_t *jwk = NULL;
+
+    // Test that 512-bit RSA modulus is rejected
+    memset(&spec, 0, sizeof(cjose_jwk_rsa_keyspec));
+    cjose_base64url_decode(RSA_512_e, strlen(RSA_512_e), &spec.e, &spec.elen, &err);
+    cjose_base64url_decode(RSA_512_n, strlen(RSA_512_n), &spec.n, &spec.nlen, &err);
+
+    jwk = cjose_jwk_create_RSA_spec(&spec, &err);
+    ck_assert_msg(NULL == jwk, "expected NULL for 512-bit RSA modulus, but got a cjose_jwk_t");
+    ck_assert_int_eq(err.code, CJOSE_ERR_INVALID_ARG);
+
+    // Cleanup
+    cjose_get_dealloc()(spec.e);
+    cjose_get_dealloc()(spec.n);
+
+    // Test that 2048-bit RSA modulus (existing test data) is accepted
+    memset(&spec, 0, sizeof(cjose_jwk_rsa_keyspec));
+    cjose_base64url_decode(RSA_e, strlen(RSA_e), &spec.e, &spec.elen, &err);
+    cjose_base64url_decode(RSA_n, strlen(RSA_n), &spec.n, &spec.nlen, &err);
+
+    jwk = cjose_jwk_create_RSA_spec(&spec, &err);
+    ck_assert_msg(NULL != jwk, "expected a cjose_jwk_t for 2048-bit RSA modulus, but got NULL");
+    ck_assert(2048 == jwk->keysize);
+    cjose_jwk_release(jwk);
+
+    // Cleanup
+    cjose_get_dealloc()(spec.e);
+    cjose_get_dealloc()(spec.n);
+}
+END_TEST
+
 Suite *cjose_jwk_suite(void)
 {
     Suite *suite = suite_create("jwk");
@@ -1433,6 +1507,8 @@ Suite *cjose_jwk_suite(void)
     tcase_add_test(tc_jwk, test_cjose_jwk_name_for_kty);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_random_weak_keysize);
+    tcase_add_test(tc_jwk, test_cjose_jwk_create_RSA_spec_weak_modulus);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_spec);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P256_random);
     tcase_add_test(tc_jwk, test_cjose_jwk_create_EC_P384_spec);

--- a/test/check_jwk.c
+++ b/test/check_jwk.c
@@ -1471,8 +1471,8 @@ START_TEST(test_cjose_jwk_create_RSA_spec_weak_modulus)
 
     // Test that 512-bit RSA modulus is rejected
     memset(&spec, 0, sizeof(cjose_jwk_rsa_keyspec));
-    cjose_base64url_decode(RSA_512_e, strlen(RSA_512_e), &spec.e, &spec.elen, &err);
-    cjose_base64url_decode(RSA_512_n, strlen(RSA_512_n), &spec.n, &spec.nlen, &err);
+    ck_assert(cjose_base64url_decode(RSA_512_e, strlen(RSA_512_e), &spec.e, &spec.elen, &err));
+    ck_assert(cjose_base64url_decode(RSA_512_n, strlen(RSA_512_n), &spec.n, &spec.nlen, &err));
 
     jwk = cjose_jwk_create_RSA_spec(&spec, &err);
     ck_assert_msg(NULL == jwk, "expected NULL for 512-bit RSA modulus, but got a cjose_jwk_t");
@@ -1484,8 +1484,8 @@ START_TEST(test_cjose_jwk_create_RSA_spec_weak_modulus)
 
     // Test that 2048-bit RSA modulus (existing test data) is accepted
     memset(&spec, 0, sizeof(cjose_jwk_rsa_keyspec));
-    cjose_base64url_decode(RSA_e, strlen(RSA_e), &spec.e, &spec.elen, &err);
-    cjose_base64url_decode(RSA_n, strlen(RSA_n), &spec.n, &spec.nlen, &err);
+    ck_assert(cjose_base64url_decode(RSA_e, strlen(RSA_e), &spec.e, &spec.elen, &err));
+    ck_assert(cjose_base64url_decode(RSA_n, strlen(RSA_n), &spec.n, &spec.nlen, &err));
 
     jwk = cjose_jwk_create_RSA_spec(&spec, &err);
     ck_assert_msg(NULL != jwk, "expected a cjose_jwk_t for 2048-bit RSA modulus, but got NULL");


### PR DESCRIPTION
Port of cisco/cjose#136 by @kunqn, cherry-picked with original authorship preserved (`1eab879`, `0fc852d`). The only conflict was the `cjose_jwk_suite(void)` signature context line in `test/check_jwk.c`; the diff is otherwise identical to the upstream PR.

Original description:

> cjose_jwk_create_RSA_spec builds an RSA JWK from supplied modulus/exponent (and optional private/CRT components) with no minimum modulus-size enforcement. RFC 7518 §3.3 requires at least 2048 bits for the RS*/PS* algorithms; cjose will create and use a 512-bit (or smaller) RSA key for RS256 signing or RSA-OAEP/RSA1_5 key wrapping.
>
> The constructor validates only that the public (n, e) or private (n, d) components are present, then builds the key — there is no check of BN_num_bits(n) against any floor. A peer using such a key operates far below the RFC-mandated strength; a 512-bit modulus is factorable with modest resources, so an attacker who can supply or substitute a weak key (e.g. via JWK import on a trust path that does not pin key size) defeats the signature or key-wrapping entirely.

Note: this is a behavior change — sub-2048-bit RSA keys are now rejected at creation/import time, which may surface for downstream consumers still using legacy keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
